### PR TITLE
Agregar documentación del HomeController

### DIFF
--- a/Sistema.Generador.Imagenes/Controllers/HomeController.cs
+++ b/Sistema.Generador.Imagenes/Controllers/HomeController.cs
@@ -4,6 +4,10 @@ using Sistema.Generador.Imagenes.Models;
 
 namespace Sistema.Generador.Imagenes.Controllers
 {
+    /// <summary>
+    /// Controlador principal de la aplicación. Provee las vistas de inicio,
+    /// privacidad y maneja la página de error.
+    /// </summary>
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
@@ -13,17 +17,26 @@ namespace Sistema.Generador.Imagenes.Controllers
             _logger = logger;
         }
 
+        /// <summary>
+        /// Muestra la página principal.
+        /// </summary>
         public IActionResult Index()
         {
             return View();
         }
 
+        /// <summary>
+        /// Muestra la página de política de privacidad.
+        /// </summary>
         public IActionResult Privacy()
         {
             return View();
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+        /// <summary>
+        /// Muestra la página de error con información de la solicitud.
+        /// </summary>
         public IActionResult Error()
         {
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });

--- a/docs/HomeController.md
+++ b/docs/HomeController.md
@@ -1,0 +1,18 @@
+# HomeController
+
+`HomeController` es el controlador predeterminado de la aplicación ASP.NET Core.
+Se encarga de entregar las vistas principales (`Index` y `Privacy`) y de manejar
+la página de error.
+
+## Acciones
+
+| Acción    | Descripción                                                                      |
+|-----------|----------------------------------------------------------------------------------|
+| `Index`   | Devuelve la vista principal de la aplicación.                                    |
+| `Privacy` | Devuelve la vista de política de privacidad.                                     |
+| `Error`   | Genera la vista de error y agrega información sobre el identificador de solicitud. |
+
+## Dependencias
+
+El controlador recibe un `ILogger<HomeController>` a través de inyección de dependencias
+para registrar eventos o diagnósticos.


### PR DESCRIPTION
## Resumen
- añadir descripciones XML al `HomeController`
- crear `docs/HomeController.md` con detalles de las acciones

## Testing
- `dotnet build Sistema.Generador.Imagenes.sln -v minimal` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_688b8b117538832c89711f64741eab40